### PR TITLE
Your beta endpoint is unresponsive?

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ rdap-client 199.71.0.160
 Or if you want to directly query a RDAP server:
 
 ```
-rdap-client -H rdap.beta.registro.br nic.br
+rdap-client -H rdap.registro.br nic.br
 ```
 
 You can check more options with:


### PR DESCRIPTION
`rdap.beta.registro.br` does not seem to be active any longer, I guess the documentation is not up to date, since your endpoint is now in the official listing with IANA.

I propose a change to: `rdap.registro.br`

If the beta is still active and I was just unlucky, please disregard this PR.

Take care,

jonasbn