### PR TITLE
Handle structured data in address in jcard

### DIFF
--- a/output/contact_info.go
+++ b/output/contact_info.go
@@ -57,11 +57,26 @@ func (c *contactInfo) setContact(entity protocol.Entity) {
 					continue
 				}
 
-				for _, v := range addresses {
-					v := v.(string)
+				for _, next := range addresses {
+					switch v := next.(type) {
+					case string:
+						if len(v) > 0 {
+							address = append(address, v)
+						}
 
-					if len(v) > 0 {
-						address = append(address, v)
+					case []interface {}:
+						//according to https://tools.ietf.org/html/rfc7095#section-3.3.1.3
+						//  spec for structured values, an array of strings is allowed here
+						for _, nestedNext := range v {
+							vv, ok := nestedNext.(string);
+							if !ok {
+								continue
+							}
+							if len(vv) > 0 {
+								address = append(address, vv)
+							}
+
+						}
 					}
 				}
 


### PR DESCRIPTION
rdap-client was crashing on output from reddog.mx rdap library output, which
turns out to fit the standard.  This patch fixes the crash and makes the client
a tiny bit more durable to standard json jcard data.
