### PR TITLE
Added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:1.19
+
+RUN go install github.com/registrobr/rdap-client@latest
+
+ENTRYPOINT ["/go/bin/rdap-client"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,41 @@
-FROM golang:1.19
+#
+# ===========
+# Build image
+# ===========
+#
+FROM golang:1.19 as builder
+COPY . /go/src/github.com/registrobr/rdap-client
+WORKDIR /go/src/github.com/registrobr/rdap-client
+RUN mkdir /apps
+RUN go build -mod=vendor -ldflags="-w -s" -o /apps/rdap-client
 
-RUN go install github.com/registrobr/rdap-client@latest
+#
+# ====================
+# Final delivery image
+# ====================
+#
+FROM debian:stable-slim
 
-ENTRYPOINT ["/go/bin/rdap-client"]
+COPY --from=builder /apps/* /apps/
+
+RUN apt update \
+    && apt -y install ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG BUILD_DATE
+ARG BUILD_VCS_REF
+ARG BUILD_VERSION
+
+ENV API_VERSION ${BUILD_VCS_REF}
+
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.description="RDAP client" \
+      org.label-schema.name="rdap-client" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.url="https://registro.br" \
+      org.label-schema.vcs-url="https://github.com/registrobr/rdap-client" \
+      org.label-schema.vcs-ref=$BUILD_VCS_REF \
+      org.label-schema.vendor="NIC.br" \
+      org.label-schema.version=$BUILD_VERSION
+
+ENTRYPOINT ["/apps/rdap-client"]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ go get github.com/registrobr/rdap-client
 
 Remember to add your **$GOPATH/bin** to your **$PATH** environment.
 
+A Dockerfile is available and can be used as in the follow example:
+
+```
+docker build -t rdap-client:latest .
+
+docker run -it --rm --name rdap-client rdap-client:latest registro.br
+```
+
 
 Usage
 -----


### PR DESCRIPTION
This PR target a simpler way to use **rdap-client** using Docker. This implementation choose to use `golang:1.19` tag instead forcing alpine version - as example - due this shared tag allow **rdap-client** to run on both Linux and Windows Core systems.