### PR TITLE
Fix go: inconsistent vendoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM golang:1.19 as builder
 COPY . /go/src/github.com/registrobr/rdap-client
 WORKDIR /go/src/github.com/registrobr/rdap-client
 RUN mkdir /apps
-RUN go mod vendor && go build -mod=vendor -ldflags="-w -s" -o /apps/rdap-client
+RUN go build -ldflags="-w -s" -o /apps/rdap-client
 
 #
 # ====================

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM golang:1.19 as builder
 COPY . /go/src/github.com/registrobr/rdap-client
 WORKDIR /go/src/github.com/registrobr/rdap-client
 RUN mkdir /apps
-RUN go build -mod=vendor -ldflags="-w -s" -o /apps/rdap-client
+RUN go mod vendor && go build -mod=vendor -ldflags="-w -s" -o /apps/rdap-client
 
 #
 # ====================


### PR DESCRIPTION
Fix error in Dockerfile line 10.

=> ERROR [builder 5/5] RUN go build -mod=vendor -ldflags="-w -s" -o /apps/rdap-client                                                                                                                                                                                                                                  0.2s
------                                                                                                                                                                                                                                                                                                                       
 > [builder 5/5] RUN go build -mod=vendor -ldflags="-w -s" -o /apps/rdap-client:                                                                                                                                                                                                                                             
#0 0.229 go: inconsistent vendoring in /go/src/github.com/registrobr/rdap-client:                                                                                                                                                                                                                                            
#0 0.229        github.com/aryann/difflib@v0.0.0-20210328193216-ff5ff6dc229b: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt                                                                                                                                                             
#0 0.229        github.com/google/btree@v0.0.0-20161217183710-316fb6d3f031: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt                                                                                                                                                               
#0 0.229        github.com/gregjones/httpcache@v0.0.0-20190611155906-901d90724c79: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt                                                                                                                                                        
#0 0.229 	github.com/peterbourgon/diskv@v2.0.1-0.20160404093648-5dfcb07a075a+incompatible: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#0 0.229 	github.com/registrobr/rdap@v1.1.2: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#0 0.229 	github.com/urfave/cli@v1.22.12: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#0 0.229 
#0 0.229 	To ignore the vendor directory, use -mod=readonly or -mod=mod.
#0 0.229 	To sync the vendor directory, run:
#0 0.229 		go mod vendor
------
Dockerfile:10
--------------------
   8 |     WORKDIR /go/src/github.com/registrobr/rdap-client
   9 |     RUN mkdir /apps
  10 | >>> RUN go build -mod=vendor -ldflags="-w -s" -o /apps/rdap-client
  11 |     
  12 |     #
--------------------
ERROR: failed to solve: process "/bin/sh -c go build -mod=vendor -ldflags=\"-w -s\" -o /apps/rdap-client" did not complete successfully: exit code: 1