### PR TITLE
Fix: IP network test failing

### DIFF
--- a/output/ipnet_tmpl.go
+++ b/output/ipnet_tmpl.go
@@ -34,8 +34,8 @@ country:       {{.IPNetwork.Country}}
 status:        {{.}}
 {{end}}\
 {{range .IPNetwork.ReverseDelegations}}\
-{{ $startAddress := .StartAddress}}
-{{ $endAddress := .EndAddress }}
+{{- $startAddress := .StartAddress -}}
+{{- $endAddress := .EndAddress -}}
 inetrev:       {{inetnum $startAddress $endAddress}}
 {{range .Nameservers}}\
 nserver:       {{.LDHName}}


### PR DESCRIPTION
The IP network test fails due to blank lines. This happens because some template lines used only for variable attributions do not remove line breaks.

```
$ go test ./...
?   	github.com/registrobr/rdap-client	[no test files]
ok  	github.com/registrobr/rdap-client/output	0.238s
```

https://pkg.go.dev/text/template#hdr-Text_and_spaces

Resolves #17